### PR TITLE
Backport libprofiler fix for MinGW 

### DIFF
--- a/mingw-w64-clang/0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch
+++ b/mingw-w64-clang/0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch
@@ -1,0 +1,34 @@
+From 879c1db5d24dcb0ac03f9f6282a09996ff3dc291 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Miku=C5=82a?= <mati865@gmail.com>
+Date: Tue, 25 Aug 2020 10:16:40 +0300
+Subject: [PATCH] [Compiler-RT] Fix profiler building with MinGW GCC
+
+Differential Revision: https://reviews.llvm.org/D86405
+---
+ lib/profile/InstrProfilingPort.h | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/lib/profile/InstrProfilingPort.h b/lib/profile/InstrProfilingPort.h
+index 4493dd512ff0..cb66c5964ad1 100644
+--- a/lib/profile/InstrProfilingPort.h
++++ b/lib/profile/InstrProfilingPort.h
+@@ -24,11 +24,17 @@
+ #define COMPILER_RT_ALWAYS_INLINE __forceinline
+ #define COMPILER_RT_CLEANUP(x)
+ #elif __GNUC__
+-#define COMPILER_RT_ALIGNAS(x) __attribute__((aligned(x)))
++#ifdef _WIN32
++#define COMPILER_RT_FTRUNCATE(f, l) _chsize(fileno(f), l)
++#define COMPILER_RT_VISIBILITY
++#define COMPILER_RT_WEAK __attribute__((selectany))
++#else
++#define COMPILER_RT_FTRUNCATE(f, l) ftruncate(fileno(f), l)
+ #define COMPILER_RT_VISIBILITY __attribute__((visibility("hidden")))
+ #define COMPILER_RT_WEAK __attribute__((weak))
++#endif
++#define COMPILER_RT_ALIGNAS(x) __attribute__((aligned(x)))
+ #define COMPILER_RT_ALLOCA __builtin_alloca
+-#define COMPILER_RT_FTRUNCATE(f,l) ftruncate(fileno(f),l)
+ #define COMPILER_RT_ALWAYS_INLINE inline __attribute((always_inline))
+ #define COMPILER_RT_CLEANUP(x) __attribute__((cleanup(x)))
+ #endif

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -60,6 +60,7 @@ source=(${_url}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0102-fix-libclang-name-for-mingw.patch"
         "0105-build-libclang-cpp-fix.patch"
         "0106-cmake-Fix-build-of-attribute-plugin-example-on-Windo.patch"
+        "0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch"
         "0301-LLD-COFF-Error-out-if-creating-a-DLL-with-too-many-e.patch"
         "0302-LLD-Allow-configuring-default-ld.lld-backend.patch"
         "0303-LLD-Ignore-ELF-tests-when-ld.lld-defaults-to-MinGW.patch"
@@ -104,6 +105,7 @@ sha256sums=('913f68c898dfb4a03b397c5e11c6a2f39d0f22ed7665c9cefa87a34423a72469'
             '01b029f2a21bd998ce374a90d41d214c891dfbb611dfbd9ca147517cd2c228ea'
             'a60f7328d84628a56a9f626e4dc26ffd0c35292c79eeba62ac3d4f25aef2fe5c'
             '0098da33ce4cfea2a6b6943c15e769345f89b84ebea28facff4cc8b92a17bc8f'
+            '6fe253d23be73ceccbc6be07ccbbe7561c5338cb71499062c41ffdf1a8b5469e'
             '0b996f438f7c7bf42c789729dfd588a65d5016386e7032e03e8cd52f1dc8bc73'
             'c74c313e442a5b8fed7c6372ac8ff8f3598c9e33db1b520f1297949e18042e55'
             '2e1705274dfc55466cc8977e61d569a685e18ce07895cbec2ccf3b848eafd8ee'
@@ -151,6 +153,10 @@ prepare() {
       "0103-Use-posix-style-path-separators-with-MinGW.patch" \
       "0105-build-libclang-cpp-fix.patch" \
       "0106-cmake-Fix-build-of-attribute-plugin-example-on-Windo.patch"
+
+  cd "${srcdir}/compiler-rt-${pkgver}.src"
+  apply_patch_with_msg \
+      "0201-Compiler-RT-Fix-profiler-building-with-MinGW-GCC.patch" \
 
   cd "${srcdir}/lld-${pkgver}.src"
   apply_patch_with_msg \


### PR DESCRIPTION
Looks like this could actually help with https://github.com/msys2/CLANG-packages/issues/11:
```
00000000 D __llvm_profile_counter_bias
00000000 R .refptr.__llvm_profile_counter_bias
         U __llvm_profile_counter_bias
```
cc @jeremyd2019