### PR TITLE
add gha workflow to build bootstrap packages

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+# AppVeyor and Drone Continuous Integration for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+# Author: Qian Hong <fracting@gmail.com>
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# Configure
+source "$DIR/ci-library.sh"
+mkdir artifacts
+git_config user.email 'ci@msys2.org'
+git_config user.name  'MSYS2 Continuous Integration'
+#git remote add upstream 'https://github.com/MSYS2/CLANG-packages'
+#git fetch --quiet upstream
+# reduce time required to install packages by disabling pacman's disk space checking
+sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
+
+pacman --noconfirm -Fy
+
+# Detect
+#list_commits  || failure 'Could not detect added commits'
+#list_packages || failure 'Could not detect changed files'
+#message 'Processing changes' "${commits[@]}"
+#test -z "${packages}" && success 'No changes in package recipes'
+#define_build_order || failure 'Could not determine build order'
+
+packages=(mingw-w64-clang mingw-w64-libmangle-git mingw-w64-tools-git mingw-w64-headers-git mingw-w64-crt-git mingw-w64-winpthreads-git)
+
+# Build
+message 'Building packages' "${packages[@]}"
+execute 'Approving recipe quality' check_recipe_quality
+
+message 'Building packages'
+for package in "${packages[@]}"; do
+    echo "::group::[build] ${package}"
+    execute 'Fetch keys' "$DIR/fetch-validpgpkeys.sh"
+    execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
+    MINGW_ARCH=clang64 execute 'Building source' makepkg-mingw --noconfirm --noprogressbar --allsource
+    echo "::endgroup::"
+
+    echo "::group::[install] ${package}"
+    execute 'Installing' yes:pacman --noprogressbar --upgrade '*.pkg.tar.*'
+    echo "::endgroup::"
+
+    echo "::group::[diff] ${package}"
+    cd "$package"
+    for pkg in *.pkg.tar.*; do
+        message "File listing diff for ${pkg}"
+        pkgname="$(echo "$pkg" | rev | cut -d- -f4- | rev)"
+        diff -Nur <(pacman -Fl "$pkgname" | sed -e 's|^[^ ]* |/|' | sort) <(pacman -Ql "$pkgname" | sed -e 's|^[^/]*||' | sort) || true
+    done
+    cd - > /dev/null
+    echo "::endgroup::"
+
+    mv "${package}"/*.pkg.tar.* artifacts
+    mv "${package}"/*.src.tar.* artifacts
+    unset package
+done
+success 'All packages built successfully'
+
+cd artifacts
+execute 'SHA-256 checksums' sha256sum *

--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -10,7 +10,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # Configure
 source "$DIR/ci-library.sh"
-mkdir artifacts
+mkdir {packages,sources}
 git_config user.email 'ci@msys2.org'
 git_config user.name  'MSYS2 Continuous Integration'
 #git remote add upstream 'https://github.com/MSYS2/CLANG-packages'
@@ -55,11 +55,16 @@ for package in "${packages[@]}"; do
     cd - > /dev/null
     echo "::endgroup::"
 
-    mv "${package}"/*.pkg.tar.* artifacts
-    mv "${package}"/*.src.tar.* artifacts
+    mv "${package}"/*.pkg.tar.* packages
+    mv "${package}"/${package}*.src.tar.* sources
     unset package
 done
-success 'All packages built successfully'
 
-cd artifacts
+cd packages
+echo "::group::Create repo"
+repo-add "${MINGW_ARCH,,}.db.tar.xz" *.pkg.tar.*
+echo "::endgroup::"
+
 execute 'SHA-256 checksums' sha256sum *
+
+success 'All packages built successfully'

--- a/.ci/ci-library.sh
+++ b/.ci/ci-library.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# Continuous Integration Library for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+# Author: Qian Hong <fracting@gmail.com>
+
+# Enable colors
+normal=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+cyan=$(tput setaf 6)
+
+# Basic status function
+_status() {
+    local type="${1}"
+    local status="${package:+${package}: }${2}"
+    local items=("${@:3}")
+    case "${type}" in
+        failure) local -n nameref_color='red';   title='[MSYS2 CI] FAILURE:' ;;
+        success) local -n nameref_color='green'; title='[MSYS2 CI] SUCCESS:' ;;
+        message) local -n nameref_color='cyan';  title='[MSYS2 CI]'
+    esac
+    printf "\n${nameref_color}${title}${normal} ${status}\n\n"
+    printf "${items:+\t%s\n}" "${items:+${items[@]}}"
+}
+
+# Convert lines to array
+_as_list() {
+    local -n nameref_list="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local lines="${4}"
+    local result=1
+    nameref_list=()
+    while IFS= read -r line; do
+        test -z "${line}" && continue
+        result=0
+        [[ "${line}" = ${filter} ]] && nameref_list+=("${line/${strip}/}")
+    done <<< "${lines}"
+    return "${result}"
+}
+
+# Changes since master or from head
+_list_changes() {
+    local list_name="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local git_options=("${@:4}")
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" upstream/master.. | sort -u)" ||
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" HEAD^.. | sort -u)"
+}
+
+# Get package information
+_package_info() {
+    local package="${1}"
+    local properties=("${@:2}")
+    for property in "${properties[@]}"; do
+        local -n nameref_property="${property}"
+        nameref_property=($(
+            MINGW_PACKAGE_PREFIX='mingw-w64' source "${package}/PKGBUILD"
+            declare -n nameref_property="${property}"
+            echo "${nameref_property[@]}"))
+    done
+}
+
+# Package provides another
+_package_provides() {
+    local package="${1}"
+    local another="${2}"
+    local pkgname provides
+    _package_info "${package}" pkgname provides
+    for pkg_name in "${pkgname[@]}";  do [[ "${pkg_name}" = "${another}" ]] && return 0; done
+    for provided in "${provides[@]}"; do [[ "${provided}" = "${another}" ]] && return 0; done
+    return 1
+}
+
+# Add package to build after required dependencies
+_build_add() {
+    local package="${1}"
+    local depends makedepends
+    for started_package in "${started_packages[@]}"; do
+        [[ "${started_package}" = "${package}" ]] && return 0
+    done
+    started_packages+=("${package}")
+    _package_info "${package}" depends makedepends
+    for dependency in "${depends[@]}" "${makedepends[@]}"; do
+        for unsorted_package in "${packages[@]}"; do
+            _package_provides "${unsorted_package}" "${dependency}" && _build_add "${unsorted_package}"
+        done
+    done
+    sorted_packages+=("${package}")
+}
+
+# Git configuration
+git_config() {
+    local name="${1}"
+    local value="${2}"
+    test -n "$(git config ${name})" && return 0
+    git config --global "${name}" "${value}" && return 0
+    failure 'Could not configure Git for makepkg'
+}
+
+# Run command with status
+execute(){
+    local status="${1}"
+    local command="${2}"
+    local arguments=("${@:3}")
+    cd "${package:-.}"
+    message "${status}"
+    if [[ "${command}" != *:* ]]
+        then ${command} ${arguments[@]}
+        else ${command%%:*} | ${command#*:} ${arguments[@]}
+    fi || failure "${status} failed"
+    cd - > /dev/null
+}
+
+# Sort packages by dependency
+define_build_order() {
+    local sorted_packages=()
+    for unsorted_package in "${packages[@]}"; do
+        _build_add "${unsorted_package}"
+    done
+    packages=("${sorted_packages[@]}")
+}
+
+# Added commits
+list_commits()  {
+    _list_changes commits '*' '#*::' --pretty=format:'%ai::[%h] %s'
+}
+
+# Changed recipes
+list_packages() {
+    local _packages
+    _list_changes _packages '*/PKGBUILD' '%/PKGBUILD' --pretty=format: --name-only || return 1
+    for _package in "${_packages[@]}"; do
+        local find_case_sensitive="$(find -name "${_package}" -type d -print -quit)"
+        test -n "${find_case_sensitive}" && packages+=("${_package}")
+    done
+    return 0
+}
+
+# Recipe quality
+check_recipe_quality() {
+    # TODO: remove this option when not anymore needed
+    if test -n "${DISABLE_QUALITY_CHECK}"; then
+        echo 'This feature is disabled.'
+        return 0
+    fi
+    saneman --format='\t%l:%c %p:%c %m' --verbose --no-terminal "${packages[@]}"
+}
+
+# Status functions
+failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
+success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }
+message() { local status="${1}"; local items=("${@:2}"); _status message "${status}"  "${items[@]}"; }

--- a/.ci/fetch-validpgpkeys.sh
+++ b/.ci/fetch-validpgpkeys.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. PKGBUILD
+
+set -e
+
+_keyserver=(
+    "keyserver.ubuntu.com"
+    "keys.gnupg.net"
+    "pgp.mit.edu"
+    "keys.openpgp.org"
+)
+for key in "${validpgpkeys[@]}"; do
+    for server in "${_keyserver[@]}"; do
+        timeout 20 /usr/bin/gpg --keyserver "${server}" --recv "${key}" && break || true
+    done
+done

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Declare files that always have LF line endings on checkout
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.7z binary
+*.a binary
+*.bz2 binary
+*.dll binary
+*.exe binary
+*.gz binary
+*.lib binary
+*.lzma binary
+*.msi binary
+*.rar binary
+*.so  binary
+*.tar binary
+*.tgz binary
+*.xz binary
+*.zip binary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,71 @@
+name: main
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { msystem: CLANG64, arch: x86_64, can-fail: false },
+          { msystem: CLANG32, arch: i686, can-fail: false },
+          #{ msystem: CLANGARM64, arch: aarch64, can-fail: true },
+        ]
+    name: ${{ matrix.msystem }}
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          path: temp
+          fetch-depth: 0
+
+      # to match the autobuild environment
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          install: git msys2-devel base-devel binutils clang lld mingw-w64-cross-clang mingw-w64-cross-clang-headers
+          update: true
+
+      - name: Add staging repo
+        shell: msys2 {0}
+        run: |
+          sed -i '1s|^|[staging]\nServer = https://repo.msys2.org/staging/\nSigLevel = Never\n|' /etc/pacman.conf
+
+      - name: Update using staging
+        run: |
+          msys2 -c 'pacman --noconfirm -Suuy'
+          msys2 -c 'pacman --noconfirm -Suu'
+
+      - name: Move Checkout
+        run: |
+          Copy-Item -Path ".\temp" -Destination "C:\_" -Recurse
+
+      - name: CI-Build
+        shell: msys2 {0}
+        continue-on-error: ${{ matrix.can-fail }}
+        run: |
+          cd /C/_
+          MINGW_ARCH=${{ matrix.msystem }} ./.ci/ci-build.sh
+
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v2
+        continue-on-error: ${{ matrix.can-fail }}
+        with:
+          name: ${{ matrix.msystem }}-packages
+          path: C:/_/artifacts/*.pkg.tar.*
+
+      - name: "Upload sources"
+        if:  ${{ matrix.msystem == 'CLANG64' }}
+        uses: actions/upload-artifact@v2
+        continue-on-error: ${{ matrix.can-fail }}
+        with:
+          name: sources
+          path: C:/_/artifacts/*.src.tar.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         continue-on-error: ${{ matrix.can-fail }}
         with:
           name: ${{ matrix.msystem }}-packages
-          path: C:/_/artifacts/*.pkg.tar.*
+          path: C:/_/packages/*
 
       - name: "Upload sources"
         if:  ${{ matrix.msystem == 'CLANG64' }}
@@ -68,4 +68,33 @@ jobs:
         continue-on-error: ${{ matrix.can-fail }}
         with:
           name: sources
-          path: C:/_/artifacts/*.src.tar.*
+          path: C:/_/sources/*
+  publish:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { tagname: clang64, artifact: CLANG64-packages },
+          { tagname: clang32, artifact: CLANG32-packages },
+          #{ tagname: clangarm64, artifact: CLANGARM64-packages, can-fail: true },
+          { tagname: sources, artifact: sources },
+        ]
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') }}
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+      - name: Get branch name
+        id: gitbranch
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
+      - uses: eine/tip@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.gitbranch.outputs.branch }}-${{ matrix.tagname }}
+          rm: true
+          files: ${{ matrix.artifact }}/*


### PR DESCRIPTION
Builds CLANG32 and CLANG64.

These packages can then be used to build a subset of MINGW-packages hacked to minimize dependencies/break circular dependencies, then those can be used to build real packages.